### PR TITLE
run-tests: download images only on x86-64

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -151,43 +151,62 @@ fi
 # Delete .swp files in the test directory, which cause Vim 8 to hang.
 find test -name '*.swp' -delete
 
+set -eu
+
+# Keep track of temporary directories for cleanup on exit
+cleanup_dirs=()
+cleanup() {
+  for dir in "${cleanup_dirs[@]}"; do
+    rm -rf "$dir"
+  done
+}
+trap cleanup EXIT
+
 # Check if docker un image is available locally
 has_image=$(docker images --quiet "${image}:${image_tag}" | wc -l)
+arch=$(docker info -f '{{ .Architecture }}')
 
-if [ "$has_image" -eq 0 ]
-then
-
+download_image() {
+  if [[ $arch != x86_64 ]]; then
+    echo "Pre-built docker image is not available for architecture ${arch}"
+    return 1
+  fi
   echo "Downloading run image ${image}:${image_tag}"
   docker pull "${image}:${image_tag}" &> /dev/null
+}
 
-  if [ $? -eq 1 ]
+if [ "$has_image" -eq 0 ] && ! download_image
+then
+  echo "Building run image ${image}:${image_tag}"
+
+  if [[ $arch != x86_64 ]] && ! docker image inspect -f '{{ .Id }}' testbed/vim:24 >/dev/null; then
+    echo "Building testbed/vim:24 for $arch"
+    tmpdir=$(mktemp -d)
+    cleanup_dirs+=( "$tmpdir" )
+    wget -O- 'https://github.com/Vimjas/vim-testbed/archive/902917c4caa50db2f2e80009b839605602f9f014.tar.gz' | tar -xz -C "$tmpdir" --strip-components 1
+    (cd "$tmpdir" && docker build -t "testbed/vim:24" .)
+    rm -rf "$tmpdir"
+  fi
+
+  docker build --build-arg GIT_VERSION="$git_version" -t "${image}:${image_tag}" .
+  docker tag "${image}:${image_tag}" "${image}:latest"
+
+  if [[ -z "${DOCKER_HUB_USER:-}" || -z "${DOCKER_HUB_PASS:-}" ]]
   then
-    echo "Could not pull image ${image}:${image_tag}"
-    echo "Building run image ${image}:${image_tag}"
-    docker build --build-arg GIT_VERSION="$git_version" -t "${image}:${image_tag}" .
-    docker tag "${image}:${image_tag}" "${image}:latest"
-
-    if [[ -z "${DOCKER_HUB_USER:-}" || -z "${DOCKER_HUB_PASS:-}" ]]
-    then
-      echo "Docker Hub credentials not set, skip push"
-    else
-      echo "Push ${image}:${image_tag} to Docker Hub"
-      echo "$DOCKER_HUB_PASS" | docker login -u "$DOCKER_HUB_USER" --password-stdin
-      docker push "${image}:${image_tag}"
-    fi
+    echo "Docker Hub credentials not set, skip push"
+  else
+    echo "Push ${image}:${image_tag} to Docker Hub"
+    echo "$DOCKER_HUB_PASS" | docker login -u "$DOCKER_HUB_USER" --password-stdin
+    docker push "${image}:${image_tag}"
   fi
 else
   echo "Docker run image ${image}:${image_tag} ready"
 fi
 
-set -e
-set -u
-
 docker tag "${image}:${image_tag}" "${image}:latest"
 
 output_dir=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
-
-trap '{ rm -rf "$output_dir"; }' EXIT
+cleanup_dirs+=( "$output_dir" )
 
 file_number=0
 pid_list=''


### PR DESCRIPTION
When running the tests on aarch64, the run-tests script tries to
download a pre-built image that is built for x86-64, and thus does not
run.

This change adds a check for the Docker daemon host platform and only
downloads the image if it will run.

Furthermore, the image dependency testbed/vim:24 is also built unless
the platform is x86_64, since it is also only provided for this
platform.

Test Plan:
Run `./run-tests` on both aarch64 and x86_64 without having
the required Docker images present (ie, `docker image ls` should not
list them).
